### PR TITLE
Set expo host ip as api host ip in dev mode

### DIFF
--- a/constants/Api.js
+++ b/constants/Api.js
@@ -1,3 +1,12 @@
+import Expo from 'expo';
+
+const { manifest } = Expo.Constants;
+
+// manifest.packagerOpts is available in dev mode
+const host = manifest.packagerOpts
+  ? manifest.debuggerHost.split(':').shift()
+  : '13.80.251.160';
+
 export default {
-  host: 'http://127.0.0.1:8080/api',
+  host: `http://${host}:8080/api`,
 };


### PR DESCRIPTION
On emulators this provided the local IP 127.0.0.1. On physical devices it provides the host IP of the expo debugger in the local LAN. Connection via Tunnel is not supported.